### PR TITLE
Persist sidebar minimize state across reloads

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -39,10 +39,11 @@ function checkIfAllowed() {
     let enclosingLine = "--------------------";
     let sidebarWidth = 350;
 
-    // Load settings and sidebar width
+    // Load settings and sidebar state
     loadSettings().then(() => {
-      chrome.storage.local.get(["sidebarWidth"], (data) => {
+      chrome.storage.local.get(["sidebarWidth", "sidebarMinimized"], (data) => {
         sidebarWidth = data.sidebarWidth || 350;
+        isSidebarMinimized = data.sidebarMinimized === true;
         createHistorySidebar();
         injectStyles();
         loadHistory();
@@ -84,6 +85,10 @@ function checkIfAllowed() {
 
     function saveSidebarWidth() {
       chrome.storage.local.set({ sidebarWidth });
+    }
+
+    function saveSidebarMinimizedState() {
+      chrome.storage.local.set({ sidebarMinimized: isSidebarMinimized });
     }
 
     function generateUniqueId() {
@@ -285,6 +290,28 @@ function checkIfAllowed() {
 
     let isSidebarMinimized = false;
 
+    function applySidebarState(minimizeButton) {
+      const button = minimizeButton || document.getElementById("minimize-sidebar-button");
+      if (!sidebar || !button) return;
+
+      if (isSidebarMinimized) {
+        sidebar.style.width = "0px";
+        sidebar.style.padding = "5px";
+        sidebar.style.overflow = "hidden";
+        sidebar.style.overflowY = "hidden";
+        button.textContent = "▶";
+        button.style.right = "35px";
+        return;
+      }
+
+      sidebar.style.width = `${sidebarWidth}px`;
+      sidebar.style.padding = "10px";
+      sidebar.style.overflow = "";
+      sidebar.style.overflowY = "auto";
+      button.textContent = "▼";
+      button.style.right = `${sidebarWidth + 5}px`;
+    }
+
     function createHistorySidebar() {
       sidebar = document.createElement("div");
       sidebar.id = "function-history-sidebar";
@@ -320,6 +347,7 @@ function checkIfAllowed() {
       document.body.appendChild(minimizeButton);
 
       minimizeButton.addEventListener("click", toggleSidebarMinimize);
+      applySidebarState(minimizeButton);
 
       const resizeHandle = document.createElement("div");
       resizeHandle.className = "resize-handle";
@@ -376,23 +404,9 @@ function checkIfAllowed() {
     }
 
     function toggleSidebarMinimize() {
-      const minimizeButton = document.getElementById("minimize-sidebar-button");
-
-      if (isSidebarMinimized) {
-        sidebar.style.width = `${sidebarWidth}px`;
-        sidebar.style.padding = "10px";
-        sidebar.style.overflowY = "auto";
-        minimizeButton.textContent = "▼";
-        minimizeButton.style.right = `${sidebarWidth + 5}px`;
-        isSidebarMinimized = false;
-      } else {
-        sidebar.style.width = "0px";
-        sidebar.style.padding = "5px";
-        sidebar.style.overflow = "hidden";
-        minimizeButton.textContent = "▶";
-        minimizeButton.style.right = "35px";
-        isSidebarMinimized = true;
-      }
+      isSidebarMinimized = !isSidebarMinimized;
+      saveSidebarMinimizedState();
+      applySidebarState();
     }
 
     function attachResizeEventListeners(handle, minimizeButton) {
@@ -408,9 +422,8 @@ function checkIfAllowed() {
         if (!isResizing) return;
         const newWidth = window.innerWidth - e.clientX;
         if (newWidth > 200 && newWidth < 600) {
-          sidebar.style.width = `${newWidth}px`;
-          minimizeButton.style.right = `${newWidth + 5}px`;
           sidebarWidth = newWidth;
+          applySidebarState(minimizeButton);
         }
       });
 


### PR DESCRIPTION
### Motivation
- Ensure the sidebar "minimized" state is persisted so the UI restores to the same collapsed/expanded appearance across page reloads and sessions. 
- Centralize the UI synchronization logic so initialization, toggling and resizing produce consistent visual state.

### Description
- Added a `sidebarMinimized` key to `chrome.storage.local` and restore it during startup before `createHistorySidebar()` is called by reading `sidebarMinimized` into `isSidebarMinimized`.
- Introduced `saveSidebarMinimizedState()` to persist `isSidebarMinimized` via `chrome.storage.local.set({ sidebarMinimized: isSidebarMinimized })` when the state changes.
- Extracted visual update logic into `applySidebarState(minimizeButton)` and call it during initialization, in `toggleSidebarMinimize()`, and during resize updates so width/padding/overflow and `#minimize-sidebar-button` `textContent/right` stay in sync.
- Made minimized appearance take precedence over restored `sidebarWidth` when `isSidebarMinimized === true` so a restored minimized state shows the closed UI.
- All changes are in `content_script.js` and the minimize toggle now simply flips `isSidebarMinimized`, saves it, and calls `applySidebarState()`.

### Testing
- Ran `node --check content_script.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad6356fa883328f822386440153b5)