### PR TITLE
Migrate sidebar UI to class-based styling in content_script.js

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -118,40 +118,13 @@ function checkIfAllowed() {
 
       const resizeHandle = sidebar.querySelector(".resize-handle");
       sidebar.innerHTML = "";
+      sidebar.classList.toggle("is-minimized", isSidebarMinimized);
 
       if (resizeHandle) {
         sidebar.appendChild(resizeHandle);
       }
 
-      const header = document.createElement("div");
-      header.style.display = "flex";
-      header.style.justifyContent = "space-between";
-      header.style.alignItems = "center";
-      header.style.marginBottom = "10px";
-
-      const title = document.createElement("h2");
-      title.textContent = "Function History";
-      title.style.margin = "0";
-      title.style.fontSize = "16px";
-
-      const buttonsContainer = document.createElement("div");
-
-      const copyButton = document.createElement("button");
-      copyButton.textContent = "Copy";
-      copyButton.title = "Copy Formatted History";
-      copyButton.style.fontSize = "12px";
-      copyButton.style.marginRight = "5px";
-
-      const clearButton = document.createElement("button");
-      clearButton.textContent = "Clear All";
-      clearButton.title = "Clear All History";
-      clearButton.style.fontSize = "12px";
-
-      buttonsContainer.appendChild(copyButton);
-      buttonsContainer.appendChild(clearButton);
-
-      header.appendChild(title);
-      header.appendChild(buttonsContainer);
+      const { header, copyButton, clearButton } = buildHeader();
       sidebar.appendChild(header);
 
       copyButton.addEventListener("click", () => {
@@ -167,60 +140,90 @@ function checkIfAllowed() {
         }
       });
 
+      const listContainer = buildHistoryList();
+
+      sidebar.appendChild(listContainer);
+    }
+
+    function buildHeader() {
+      const header = document.createElement("div");
+      header.className = "cpt-header";
+
+      const title = document.createElement("h2");
+      title.className = "cpt-title";
+      title.textContent = "Function History";
+
+      const buttonsContainer = document.createElement("div");
+      buttonsContainer.className = "cpt-btn-group";
+
+      const copyButton = document.createElement("button");
+      copyButton.className = "cpt-btn";
+      copyButton.textContent = "Copy";
+      copyButton.title = "Copy Formatted History";
+
+      const clearButton = document.createElement("button");
+      clearButton.className = "cpt-btn";
+      clearButton.textContent = "Clear All";
+      clearButton.title = "Clear All History";
+
+      buttonsContainer.appendChild(copyButton);
+      buttonsContainer.appendChild(clearButton);
+      header.appendChild(title);
+      header.appendChild(buttonsContainer);
+
+      return { header, copyButton, clearButton };
+    }
+
+    function buildHistoryList() {
       const listContainer = document.createElement("div");
       listContainer.id = "function-history-list";
+      listContainer.className = "cpt-history-list";
 
       functionHistory.forEach((func, index) => {
         const item = createHistoryItem(func, index);
         listContainer.appendChild(item);
       });
 
-      sidebar.appendChild(listContainer);
+      return listContainer;
     }
 
     function createHistoryItem(func, index) {
       const item = document.createElement("div");
-      item.className = "function-history-item";
+      item.className = "function-history-item cpt-item";
       item.dataset.index = index;
 
       const controls = document.createElement("span");
-      controls.className = "function-history-controls";
-      controls.style.marginRight = "10px";
+      controls.className = "function-history-controls cpt-controls";
 
       const addButton = document.createElement("button");
       addButton.textContent = "+";
       addButton.title = "Increase Level";
-      addButton.className = "add-sublevel-button";
+      addButton.className = "add-sublevel-button cpt-btn";
       addButton.dataset.index = index;
-      addButton.style.marginRight = "5px";
 
       const decreaseButton = document.createElement("button");
       decreaseButton.textContent = "-";
       decreaseButton.title = "Decrease Level";
-      decreaseButton.className = "decrease-sublevel-button";
+      decreaseButton.className = "decrease-sublevel-button cpt-btn";
       decreaseButton.dataset.index = index;
-      decreaseButton.style.marginRight = "5px";
 
       const upButton = document.createElement("button");
       upButton.textContent = "↑";
       upButton.title = "Move Up";
-      upButton.className = "move-up-button";
+      upButton.className = "move-up-button cpt-btn";
       upButton.dataset.index = index;
-      upButton.style.marginRight = "5px";
 
       const downButton = document.createElement("button");
       downButton.textContent = "↓";
       downButton.title = "Move Down";
-      downButton.className = "move-down-button";
+      downButton.className = "move-down-button cpt-btn";
       downButton.dataset.index = index;
-      downButton.style.marginRight = "5px";
 
       const deleteButton = document.createElement("button");
       deleteButton.textContent = "×";
       deleteButton.title = "Delete";
-      deleteButton.className = "delete-button";
+      deleteButton.className = "delete-button cpt-btn";
       deleteButton.dataset.index = index;
-      deleteButton.style.marginRight = "5px";
 
       controls.appendChild(addButton);
       controls.appendChild(decreaseButton);
@@ -229,29 +232,25 @@ function checkIfAllowed() {
       controls.appendChild(deleteButton);
 
       const levelIndicator = document.createElement("span");
+      levelIndicator.className = "cpt-level-indicator";
       levelIndicator.textContent = "-".repeat(func.level);
-      levelIndicator.style.marginLeft = "5px";
 
       const nameSpan = document.createElement("span");
-      nameSpan.style.position = "relative";
+      nameSpan.className = "cpt-name";
 
       if (includeLinks && func.link) {
         const link = document.createElement("a");
         link.href = func.link;
         link.textContent = func.name;
         link.target = "_blank";
-        link.style.textDecoration = "none";
-        link.style.color = "#007bff";
+        link.className = "cpt-link";
         nameSpan.appendChild(link);
 
         const editButton = document.createElement("button");
         editButton.textContent = "✎";
         editButton.title = "Edit URL";
-        editButton.className = "edit-url-button";
+        editButton.className = "edit-url-button cpt-btn cpt-btn-edit";
         editButton.dataset.index = index;
-        editButton.style.marginLeft = "5px";
-        editButton.style.fontSize = "12px";
-        editButton.style.cursor = "pointer";
         nameSpan.appendChild(editButton);
 
         editButton.addEventListener("click", (e) => {
@@ -288,21 +287,8 @@ function checkIfAllowed() {
     function createHistorySidebar() {
       sidebar = document.createElement("div");
       sidebar.id = "function-history-sidebar";
-
-      sidebar.style.position = "fixed";
-      sidebar.style.top = "0";
-      sidebar.style.right = "0";
+      sidebar.className = "cpt-sidebar";
       sidebar.style.width = `${sidebarWidth}px`;
-      sidebar.style.height = "100%";
-      sidebar.style.backgroundColor = "#f9f9f9";
-      sidebar.style.overflowY = "auto";
-      sidebar.style.zIndex = "1000";
-      sidebar.style.padding = "10px";
-      sidebar.style.borderLeft = "1px solid #ccc";
-      sidebar.style.fontFamily = "Arial, sans-serif";
-      sidebar.style.fontSize = "14px";
-      sidebar.style.boxSizing = "border-box";
-      sidebar.style.transition = "width 0.3s ease";
 
       document.body.appendChild(sidebar);
 
@@ -310,26 +296,15 @@ function checkIfAllowed() {
       minimizeButton.textContent = "▼";
       minimizeButton.title = "Minimize Sidebar";
       minimizeButton.id = "minimize-sidebar-button";
-      minimizeButton.style.position = "fixed";
-      minimizeButton.style.top = "10px";
+      minimizeButton.className = "cpt-minimize-button cpt-btn";
       minimizeButton.style.right = `${sidebarWidth + 5}px`;
-      minimizeButton.style.fontSize = "16px";
-      minimizeButton.style.cursor = "pointer";
-      minimizeButton.style.zIndex = "1001";
 
       document.body.appendChild(minimizeButton);
 
       minimizeButton.addEventListener("click", toggleSidebarMinimize);
 
       const resizeHandle = document.createElement("div");
-      resizeHandle.className = "resize-handle";
-      resizeHandle.style.position = "absolute";
-      resizeHandle.style.left = "-5px";
-      resizeHandle.style.top = "0";
-      resizeHandle.style.width = "10px";
-      resizeHandle.style.height = "100%";
-      resizeHandle.style.cursor = "ew-resize";
-      resizeHandle.style.zIndex = "1001";
+      resizeHandle.className = "resize-handle cpt-resize-handle";
       sidebar.appendChild(resizeHandle);
 
       attachResizeEventListeners(resizeHandle, minimizeButton);
@@ -380,15 +355,13 @@ function checkIfAllowed() {
 
       if (isSidebarMinimized) {
         sidebar.style.width = `${sidebarWidth}px`;
-        sidebar.style.padding = "10px";
-        sidebar.style.overflowY = "auto";
+        sidebar.classList.toggle("is-minimized", false);
         minimizeButton.textContent = "▼";
         minimizeButton.style.right = `${sidebarWidth + 5}px`;
         isSidebarMinimized = false;
       } else {
         sidebar.style.width = "0px";
-        sidebar.style.padding = "5px";
-        sidebar.style.overflow = "hidden";
+        sidebar.classList.toggle("is-minimized", true);
         minimizeButton.textContent = "▶";
         minimizeButton.style.right = "35px";
         isSidebarMinimized = true;
@@ -516,40 +489,121 @@ function checkIfAllowed() {
     function injectStyles() {
       const style = document.createElement("style");
       style.textContent = `
-        .function-history-item {
+        :root {
+          --cpt-bg: #f9f9f9;
+          --cpt-text: #1f2937;
+          --cpt-border: #d1d5db;
+          --cpt-btn-bg: #ffffff;
+          --cpt-btn-hover: #e5e7eb;
+          --cpt-btn-border: #cbd5e1;
+          --cpt-link: #2563eb;
+          --cpt-focus: #3b82f6;
+          --cpt-success: #4caf50;
+          --cpt-success-text: #ffffff;
+        }
+
+        .cpt-sidebar {
+          position: fixed;
+          top: 0;
+          right: 0;
+          height: 100%;
+          background-color: var(--cpt-bg);
+          color: var(--cpt-text);
+          overflow-y: auto;
+          z-index: 1000;
+          padding: 10px;
+          border-left: 1px solid var(--cpt-border);
+          font-family: Arial, sans-serif;
+          font-size: 14px;
+          box-sizing: border-box;
+          transition: width 0.3s ease, padding 0.3s ease;
+        }
+
+        .cpt-sidebar.is-minimized {
+          padding: 5px;
+          overflow: hidden;
+        }
+
+        .cpt-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 10px;
+        }
+
+        .cpt-title {
+          margin: 0;
+          font-size: 16px;
+        }
+
+        .cpt-btn-group {
+          display: flex;
+          gap: 5px;
+        }
+
+        .cpt-btn {
+          padding: 4px 8px;
+          border-radius: 6px;
+          border: 1px solid var(--cpt-btn-border);
+          background: var(--cpt-btn-bg);
+          color: var(--cpt-text);
+          font-size: 12px;
+          cursor: pointer;
+          line-height: 1.2;
+          transition: background-color 0.2s ease;
+        }
+
+        .cpt-btn:hover {
+          background-color: var(--cpt-btn-hover);
+        }
+
+        .cpt-btn:focus-visible {
+          outline: 2px solid var(--cpt-focus);
+          outline-offset: 1px;
+        }
+
+        .cpt-item {
           display: flex;
           align-items: center;
           margin-bottom: 5px;
           position: relative;
+          gap: 6px;
         }
-  
-        .function-history-item span {
-          margin-right: 10px;
+
+        .cpt-controls {
+          display: inline-flex;
+          gap: 5px;
+          margin-right: 6px;
         }
-  
-        .function-history-controls button {
-          margin-right: 5px;
-          padding: 2px 5px;
-          font-size: 12px;
-          cursor: pointer;
+
+        .cpt-level-indicator {
+          min-width: 8px;
         }
-  
-        .function-history-controls button:hover {
-          background-color: #e0e0e0;
+
+        .cpt-name {
+          position: relative;
+          display: inline-flex;
+          align-items: center;
+          gap: 5px;
         }
-  
-        #clear-history-button, #copy-history-button {
-          padding: 5px 10px;
-          font-size: 12px;
-          cursor: pointer;
-          margin-right: 5px;
+
+        .cpt-link {
+          text-decoration: none;
+          color: var(--cpt-link);
         }
-  
-        #clear-history-button:hover, #copy-history-button:hover {
-          background-color: #e0e0e0;
+
+        .cpt-minimize-button {
+          position: fixed;
+          top: 10px;
+          z-index: 1001;
+          font-size: 16px;
         }
-  
-        .resize-handle {
+
+        .cpt-btn-edit {
+          padding: 2px 6px;
+        }
+
+        .cpt-resize-handle {
           position: absolute;
           left: -5px;
           top: 0;
@@ -558,7 +612,7 @@ function checkIfAllowed() {
           cursor: ew-resize;
           z-index: 1001;
         }
-  
+
         .url-tooltip {
           position: absolute;
           background-color: #333;
@@ -570,6 +624,17 @@ function checkIfAllowed() {
           z-index: 1002;
           display: none;
         }
+
+        .cpt-toast {
+          position: fixed;
+          bottom: 10px;
+          right: 10px;
+          background-color: var(--cpt-success);
+          color: var(--cpt-success-text);
+          padding: 10px;
+          border-radius: 5px;
+          z-index: 1001;
+        }
       `;
       document.head.appendChild(style);
     }
@@ -577,14 +642,7 @@ function checkIfAllowed() {
     function showTemporaryMessage(message) {
       const msg = document.createElement("div");
       msg.textContent = message;
-      msg.style.position = "fixed";
-      msg.style.bottom = "10px";
-      msg.style.right = "10px";
-      msg.style.backgroundColor = "#4caf50";
-      msg.style.color = "white";
-      msg.style.padding = "10px";
-      msg.style.borderRadius = "5px";
-      msg.style.zIndex = "1001";
+      msg.className = "cpt-toast";
       document.body.appendChild(msg);
 
       setTimeout(() => {


### PR DESCRIPTION
### Motivation
- Replace inline-style-heavy UI generation with class-based styling to improve maintainability and make future dark-mode support easier.
- Make DOM creation and state changes easier to inspect and reason about by separating UI structure into small builder functions.

### Description
- Replaced many inline `style.xxx` assignments with `className`/`classList` usage and introduced CSS classes and custom properties in `injectStyles()` (examples: `.cpt-sidebar`, `.cpt-header`, `.cpt-btn`, `.cpt-item`, `.cpt-minimize-button`, `.cpt-resize-handle`, `.cpt-toast` and `--cpt-*` variables) in `content_script.js`.
- Factored header and list DOM creation into `buildHeader()` and `buildHistoryList()` and updated `createHistoryItem()` to apply `cpt-*` classes and unify action buttons with a shared `cpt-btn` style (affects Copy / Clear / + / - / ↑ / ↓ / × / ✎).
- Switched minimized-state handling to class-based representation using `sidebar.classList.toggle('is-minimized', ...)` and updated `createHistorySidebar()` / `toggleSidebarMinimize()` to use the new classes while keeping width adjustments in JS.
- Kept existing behaviors intact (history add, copy, delete, level up/down, reorder, URL edit, resize) by preserving event wiring and dataset usage while making DOM generation easier to review.

### Testing
- Ran `node --check content_script.js` and it completed with no syntax errors.
- Performed a manual review of event handlers and function flows for `add`/`copy`/`delete`/`level`/`move`/`url edit`/`resize` to verify wiring and dataset usage were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad639a0188332a3dae62aae8781bd)