### PR TITLE
Persist sidebar minimized state on toggle

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -380,20 +380,12 @@ function checkIfAllowed() {
 
     function toggleSidebarMinimize() {
       const minimizeButton = document.getElementById("minimize-sidebar-button");
+      if (!minimizeButton || !sidebar) return;
 
-      if (isSidebarMinimized) {
-        sidebar.style.width = `${sidebarWidth}px`;
-        sidebar.classList.toggle("is-minimized", false);
-        minimizeButton.textContent = "▼";
-        minimizeButton.style.right = `${sidebarWidth + 5}px`;
-        isSidebarMinimized = false;
-      } else {
-        sidebar.style.width = "0px";
-        sidebar.classList.toggle("is-minimized", true);
-        minimizeButton.textContent = "▶";
-        minimizeButton.style.right = "35px";
-        isSidebarMinimized = true;
-      }
+      isSidebarMinimized = !isSidebarMinimized;
+      sidebar.classList.toggle("is-minimized", isSidebarMinimized);
+      applySidebarState(minimizeButton);
+      saveSidebarMinimizedState();
     }
 
     function attachResizeEventListeners(handle, minimizeButton) {


### PR DESCRIPTION
### Motivation
- The sidebar minimize/restore behavior was applied directly to DOM and not persisted, so the closed/open state was lost after a page reload.

### Description
- Simplify `toggleSidebarMinimize` to flip the single source of truth `isSidebarMinimized`, call `applySidebarState(minimizeButton)`, and persist the value via `saveSidebarMinimizedState()`.
- Add a null guard to `toggleSidebarMinimize` to return early when `sidebar` or the minimize button are not yet available.
- All changes were made in `content_script.js`.

### Testing
- Ran `node --check content_script.js` which completed without errors.
- Ran a small Playwright script to open a blank page and capture `artifacts/sidebar-state.png` to validate runtime injection, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad9910188833292a85c842e6754f0)